### PR TITLE
Update to terraform-plugin-framework 0.12 and fix import order

### DIFF
--- a/ec/acc/acc_prereq.go
+++ b/ec/acc/acc_prereq.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/auth"
+
 	"github.com/elastic/terraform-provider-ec/ec"
 )
 

--- a/ec/acc/deployment_checks_test.go
+++ b/ec/acc/deployment_checks_test.go
@@ -20,11 +20,12 @@ package acc
 import (
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/deputil"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func testAccCheckDeploymentExists(name string) resource.TestCheckFunc {

--- a/ec/acc/deployment_destroy_test.go
+++ b/ec/acc/deployment_destroy_test.go
@@ -20,9 +20,10 @@ package acc
 import (
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func testAccDeploymentDestroy(s *terraform.State) error {

--- a/ec/acc/deployment_elasticsearch_kesytore_destroy_test.go
+++ b/ec/acc/deployment_elasticsearch_kesytore_destroy_test.go
@@ -20,9 +20,10 @@ package acc
 import (
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/eskeystoreapi"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func testAccDeploymentElasticsearchKeystoreDestroy(s *terraform.State) error {

--- a/ec/acc/deployment_elasticsearch_kesytore_test.go
+++ b/ec/acc/deployment_elasticsearch_kesytore_test.go
@@ -21,10 +21,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/elastic/cloud-sdk-go/pkg/multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
 )
 
 func TestAccDeploymentElasticsearchKeystore_full(t *testing.T) {

--- a/ec/acc/deployment_extension_bundle_file_test.go
+++ b/ec/acc/deployment_extension_bundle_file_test.go
@@ -27,10 +27,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/elastic/cloud-sdk-go/pkg/client/extensions"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/elastic/cloud-sdk-go/pkg/client/extensions"
 )
 
 func TestAccDeploymentExtension_bundleFile(t *testing.T) {

--- a/ec/acc/deployment_extension_destroy_test.go
+++ b/ec/acc/deployment_extension_destroy_test.go
@@ -20,9 +20,10 @@ package acc
 import (
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
 	"github.com/elastic/cloud-sdk-go/pkg/client/extensions"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func testAccExtensionDestroy(s *terraform.State) error {

--- a/ec/acc/deployment_failed_upgrade_retry_test.go
+++ b/ec/acc/deployment_failed_upgrade_retry_test.go
@@ -23,7 +23,7 @@ import (
 	"regexp"
 	"testing"
 
-	semver "github.com/blang/semver/v4"
+	"github.com/blang/semver/v4"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )

--- a/ec/acc/deployment_sweep_test.go
+++ b/ec/acc/deployment_sweep_test.go
@@ -23,6 +23,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
@@ -30,7 +32,6 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/plan"
 	"github.com/elastic/cloud-sdk-go/pkg/plan/planutil"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func init() {

--- a/ec/acc/deployment_traffic_filter_checks_test.go
+++ b/ec/acc/deployment_traffic_filter_checks_test.go
@@ -20,10 +20,11 @@ package acc
 import (
 	"fmt"
 
-	"github.com/elastic/cloud-sdk-go/pkg/api"
-	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/trafficfilterapi"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/trafficfilterapi"
 )
 
 func testAccCheckDeploymentTrafficFilterExists(name string) resource.TestCheckFunc {

--- a/ec/acc/deployment_traffic_filter_destroy_test.go
+++ b/ec/acc/deployment_traffic_filter_destroy_test.go
@@ -20,9 +20,10 @@ package acc
 import (
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/trafficfilterapi"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func testAccDeploymentTrafficFilterDestroy(s *terraform.State) error {

--- a/ec/acc/deployment_traffic_filter_sweep_test.go
+++ b/ec/acc/deployment_traffic_filter_sweep_test.go
@@ -21,10 +21,11 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/trafficfilterapi"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func init() {

--- a/ec/acc/deployment_with_extension_bundle_test.go
+++ b/ec/acc/deployment_with_extension_bundle_test.go
@@ -23,10 +23,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/elastic/cloud-sdk-go/pkg/multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
 )
 
 func TestAccDeployment_withExtension(t *testing.T) {

--- a/ec/ecdatasource/deploymentdatasource/datasource_test.go
+++ b/ec/ecdatasource/deploymentdatasource/datasource_test.go
@@ -19,15 +19,18 @@ package deploymentdatasource
 
 import (
 	"context"
-	"github.com/elastic/terraform-provider-ec/ec/internal/util"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"testing"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )
 
 func Test_modelToState(t *testing.T) {

--- a/ec/ecdatasource/deploymentdatasource/flatteners_apm.go
+++ b/ec/ecdatasource/deploymentdatasource/flatteners_apm.go
@@ -19,10 +19,12 @@ package deploymentdatasource
 
 import (
 	"context"
-	"github.com/elastic/cloud-sdk-go/pkg/models"
+
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
 
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )

--- a/ec/ecdatasource/deploymentdatasource/flatteners_apm_test.go
+++ b/ec/ecdatasource/deploymentdatasource/flatteners_apm_test.go
@@ -19,10 +19,11 @@ package deploymentdatasource
 
 import (
 	"context"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
-	"testing"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"

--- a/ec/ecdatasource/deploymentdatasource/flatteners_elasticsearch.go
+++ b/ec/ecdatasource/deploymentdatasource/flatteners_elasticsearch.go
@@ -23,10 +23,11 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
 
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )

--- a/ec/ecdatasource/deploymentdatasource/flatteners_elasticsearch_test.go
+++ b/ec/ecdatasource/deploymentdatasource/flatteners_elasticsearch_test.go
@@ -21,12 +21,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
-	"github.com/elastic/cloud-sdk-go/pkg/models"
-	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 )
 
 func Test_flattenElasticsearchResources(t *testing.T) {

--- a/ec/ecdatasource/deploymentdatasource/flatteners_enterprise_search.go
+++ b/ec/ecdatasource/deploymentdatasource/flatteners_enterprise_search.go
@@ -19,10 +19,12 @@ package deploymentdatasource
 
 import (
 	"context"
-	"github.com/elastic/cloud-sdk-go/pkg/models"
+
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
 
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )

--- a/ec/ecdatasource/deploymentdatasource/flatteners_enterprise_search_test.go
+++ b/ec/ecdatasource/deploymentdatasource/flatteners_enterprise_search_test.go
@@ -21,12 +21,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
-	"github.com/elastic/cloud-sdk-go/pkg/models"
-	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 )
 
 func Test_flattenEnterpriseSearchResource(t *testing.T) {

--- a/ec/ecdatasource/deploymentdatasource/flatteners_integrations_server.go
+++ b/ec/ecdatasource/deploymentdatasource/flatteners_integrations_server.go
@@ -19,10 +19,12 @@ package deploymentdatasource
 
 import (
 	"context"
-	"github.com/elastic/cloud-sdk-go/pkg/models"
+
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
 
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )

--- a/ec/ecdatasource/deploymentdatasource/flatteners_integrations_server_test.go
+++ b/ec/ecdatasource/deploymentdatasource/flatteners_integrations_server_test.go
@@ -21,12 +21,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
-	"github.com/elastic/cloud-sdk-go/pkg/models"
-	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 )
 
 func Test_flattenIntegrationsServerResource(t *testing.T) {

--- a/ec/ecdatasource/deploymentdatasource/flatteners_kibana.go
+++ b/ec/ecdatasource/deploymentdatasource/flatteners_kibana.go
@@ -19,10 +19,12 @@ package deploymentdatasource
 
 import (
 	"context"
-	"github.com/elastic/cloud-sdk-go/pkg/models"
+
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
 
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )

--- a/ec/ecdatasource/deploymentdatasource/flatteners_kibana_test.go
+++ b/ec/ecdatasource/deploymentdatasource/flatteners_kibana_test.go
@@ -21,12 +21,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
-	"github.com/elastic/cloud-sdk-go/pkg/models"
-	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 )
 
 func Test_flattenKibanaResources(t *testing.T) {

--- a/ec/ecdatasource/deploymentdatasource/flatteners_observability.go
+++ b/ec/ecdatasource/deploymentdatasource/flatteners_observability.go
@@ -19,10 +19,12 @@ package deploymentdatasource
 
 import (
 	"context"
-	"github.com/elastic/cloud-sdk-go/pkg/models"
+
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
 )
 
 // flattenObservability parses a deployment's observability settings.

--- a/ec/ecdatasource/deploymentdatasource/flatteners_observability_test.go
+++ b/ec/ecdatasource/deploymentdatasource/flatteners_observability_test.go
@@ -21,10 +21,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
-	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
 )
 
 func TestFlattenObservability(t *testing.T) {

--- a/ec/ecdatasource/deploymentdatasource/flatteners_traffic_filter.go
+++ b/ec/ecdatasource/deploymentdatasource/flatteners_traffic_filter.go
@@ -19,10 +19,12 @@ package deploymentdatasource
 
 import (
 	"context"
-	"github.com/elastic/cloud-sdk-go/pkg/models"
+
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
 )
 
 // flattenTrafficFiltering parses a deployment's traffic filtering settings.

--- a/ec/ecdatasource/deploymentdatasource/flatteners_traffic_filter_test.go
+++ b/ec/ecdatasource/deploymentdatasource/flatteners_traffic_filter_test.go
@@ -21,8 +21,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
 )
 
 func Test_flattenTrafficFiltering(t *testing.T) {

--- a/ec/ecdatasource/deploymentdatasource/schema.go
+++ b/ec/ecdatasource/deploymentdatasource/schema.go
@@ -19,12 +19,13 @@ package deploymentdatasource
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func (s DataSourceType) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+func (d *DataSource) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
 	return tfsdk.Schema{
 		Attributes: map[string]tfsdk.Attribute{
 			"alias": {

--- a/ec/ecdatasource/deploymentsdatasource/datasource.go
+++ b/ec/ecdatasource/deploymentsdatasource/datasource.go
@@ -22,37 +22,49 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/elastic/terraform-provider-ec/ec/internal"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/elastic/terraform-provider-ec/ec/internal"
 )
 
-var _ provider.DataSourceType = (*DataSourceType)(nil)
+var _ datasource.DataSource = &DataSource{}
+var _ datasource.DataSourceWithConfigure = &DataSource{}
+var _ datasource.DataSourceWithGetSchema = &DataSource{}
+var _ datasource.DataSourceWithMetadata = &DataSource{}
 
-type DataSourceType struct{}
-
-func (s DataSourceType) NewDataSource(ctx context.Context, in provider.Provider) (datasource.DataSource, diag.Diagnostics) {
-	p, diags := internal.ConvertProviderType(in)
-
-	return &deploymentsDataSource{
-		p: p,
-	}, diags
+type DataSource struct {
+	client *api.API
 }
 
-var _ datasource.DataSource = (*deploymentsDataSource)(nil)
-
-type deploymentsDataSource struct {
-	p internal.Provider
+func (d *DataSource) Configure(ctx context.Context, request datasource.ConfigureRequest, response *datasource.ConfigureResponse) {
+	client, diags := internal.ConvertProviderData(request.ProviderData)
+	response.Diagnostics.Append(diags...)
+	d.client = client
 }
 
-func (d deploymentsDataSource) Read(ctx context.Context, request datasource.ReadRequest, response *datasource.ReadResponse) {
+func (d *DataSource) Metadata(ctx context.Context, request datasource.MetadataRequest, response *datasource.MetadataResponse) {
+	response.TypeName = request.ProviderTypeName + "_deployments"
+}
+
+func (d DataSource) Read(ctx context.Context, request datasource.ReadRequest, response *datasource.ReadResponse) {
+	// Prevent panic if the provider has not been configured.
+	if d.client == nil {
+		response.Diagnostics.AddError(
+			"Unconfigured API Client",
+			"Expected configured API client. Please report this issue to the provider developers.",
+		)
+
+		return
+	}
+
 	var newState modelV0
 	response.Diagnostics.Append(request.Config.Get(ctx, &newState)...)
 	if response.Diagnostics.HasError() {
@@ -66,7 +78,7 @@ func (d deploymentsDataSource) Read(ctx context.Context, request datasource.Read
 	}
 
 	res, err := deploymentapi.Search(deploymentapi.SearchParams{
-		API:     d.p.GetClient(),
+		API:     d.client,
 		Request: query,
 	})
 	if err != nil {

--- a/ec/ecdatasource/deploymentsdatasource/datasource_test.go
+++ b/ec/ecdatasource/deploymentsdatasource/datasource_test.go
@@ -19,13 +19,15 @@ package deploymentsdatasource
 
 import (
 	"context"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_modelToState(t *testing.T) {

--- a/ec/ecdatasource/deploymentsdatasource/expanders.go
+++ b/ec/ecdatasource/deploymentsdatasource/expanders.go
@@ -20,11 +20,13 @@ package deploymentsdatasource
 import (
 	"context"
 	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 // expandFilters expands all filters into a search request model

--- a/ec/ecdatasource/deploymentsdatasource/expanders_test.go
+++ b/ec/ecdatasource/deploymentsdatasource/expanders_test.go
@@ -20,15 +20,18 @@ package deploymentsdatasource
 import (
 	"context"
 	"encoding/json"
-	"github.com/elastic/terraform-provider-ec/ec/internal/util"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"testing"
 
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )
 
 func Test_expandFilters(t *testing.T) {

--- a/ec/ecdatasource/deploymentsdatasource/schema.go
+++ b/ec/ecdatasource/deploymentsdatasource/schema.go
@@ -19,14 +19,16 @@ package deploymentsdatasource
 
 import (
 	"context"
-	"github.com/elastic/terraform-provider-ec/ec/internal/planmodifier"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/elastic/terraform-provider-ec/ec/internal/planmodifier"
 )
 
-func (s DataSourceType) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+func (d *DataSource) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
 	return tfsdk.Schema{
 		Attributes: map[string]tfsdk.Attribute{
 			"name_prefix": {

--- a/ec/ecdatasource/stackdatasource/datasource.go
+++ b/ec/ecdatasource/stackdatasource/datasource.go
@@ -22,35 +22,48 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/elastic/cloud-sdk-go/pkg/api/stackapi"
-	"github.com/elastic/cloud-sdk-go/pkg/models"
-	"github.com/elastic/terraform-provider-ec/ec/internal"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/stackapi"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+
+	"github.com/elastic/terraform-provider-ec/ec/internal"
 )
 
-var _ provider.DataSourceType = (*DataSourceType)(nil)
+var _ datasource.DataSource = &DataSource{}
+var _ datasource.DataSourceWithConfigure = &DataSource{}
+var _ datasource.DataSourceWithGetSchema = &DataSource{}
+var _ datasource.DataSourceWithMetadata = &DataSource{}
 
-type DataSourceType struct{}
-
-func (s DataSourceType) NewDataSource(ctx context.Context, in provider.Provider) (datasource.DataSource, diag.Diagnostics) {
-	p, diags := internal.ConvertProviderType(in)
-
-	return &stackDataSource{
-		p: p,
-	}, diags
+type DataSource struct {
+	client *api.API
 }
 
-var _ datasource.DataSource = (*stackDataSource)(nil)
-
-type stackDataSource struct {
-	p internal.Provider
+func (d *DataSource) Configure(ctx context.Context, request datasource.ConfigureRequest, response *datasource.ConfigureResponse) {
+	client, diags := internal.ConvertProviderData(request.ProviderData)
+	response.Diagnostics.Append(diags...)
+	d.client = client
 }
 
-func (d stackDataSource) Read(ctx context.Context, request datasource.ReadRequest, response *datasource.ReadResponse) {
+func (d *DataSource) Metadata(ctx context.Context, request datasource.MetadataRequest, response *datasource.MetadataResponse) {
+	response.TypeName = request.ProviderTypeName + "_stack"
+}
+
+func (d DataSource) Read(ctx context.Context, request datasource.ReadRequest, response *datasource.ReadResponse) {
+	// Prevent panic if the provider has not been configured.
+	if d.client == nil {
+		response.Diagnostics.AddError(
+			"Unconfigured API Client",
+			"Expected configured API client. Please report this issue to the provider developers.",
+		)
+
+		return
+	}
+
 	var newState modelV0
 	response.Diagnostics.Append(request.Config.Get(ctx, &newState)...)
 	if response.Diagnostics.HasError() {
@@ -58,7 +71,7 @@ func (d stackDataSource) Read(ctx context.Context, request datasource.ReadReques
 	}
 
 	res, err := stackapi.List(stackapi.ListParams{
-		API:    d.p.GetClient(),
+		API:    d.client,
 		Region: newState.Region.Value,
 	})
 	if err != nil {

--- a/ec/ecdatasource/stackdatasource/datasource_test.go
+++ b/ec/ecdatasource/stackdatasource/datasource_test.go
@@ -21,15 +21,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/elastic/terraform-provider-ec/ec/internal/util"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"regexp/syntax"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )
 
 func Test_modelToState(t *testing.T) {

--- a/ec/ecdatasource/stackdatasource/flatteners_apm.go
+++ b/ec/ecdatasource/stackdatasource/flatteners_apm.go
@@ -19,10 +19,12 @@ package stackdatasource
 
 import (
 	"context"
-	"github.com/elastic/cloud-sdk-go/pkg/models"
+
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
 )
 
 // flattenStackVersionApmConfig takes a StackVersionApmConfigs and flattens it.

--- a/ec/ecdatasource/stackdatasource/flatteners_apm_test.go
+++ b/ec/ecdatasource/stackdatasource/flatteners_apm_test.go
@@ -19,13 +19,15 @@ package stackdatasource
 
 import (
 	"context"
-	"github.com/elastic/terraform-provider-ec/ec/internal/util"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
-	"testing"
 
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+
+	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )
 
 func Test_flattenApmResource(t *testing.T) {

--- a/ec/ecdatasource/stackdatasource/flatteners_elasticsearch.go
+++ b/ec/ecdatasource/stackdatasource/flatteners_elasticsearch.go
@@ -19,10 +19,12 @@ package stackdatasource
 
 import (
 	"context"
-	"github.com/elastic/cloud-sdk-go/pkg/models"
+
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
 )
 
 // flattenStackVersionElasticsearchConfig takes a StackVersionElasticsearchConfig and flattens it.

--- a/ec/ecdatasource/stackdatasource/flatteners_elasticsearch_test.go
+++ b/ec/ecdatasource/stackdatasource/flatteners_elasticsearch_test.go
@@ -19,13 +19,15 @@ package stackdatasource
 
 import (
 	"context"
-	"github.com/elastic/terraform-provider-ec/ec/internal/util"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
-	"testing"
 
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+
+	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )
 
 func Test_flattenElasticsearchResource(t *testing.T) {

--- a/ec/ecdatasource/stackdatasource/flatteners_enterprise_search.go
+++ b/ec/ecdatasource/stackdatasource/flatteners_enterprise_search.go
@@ -19,10 +19,12 @@ package stackdatasource
 
 import (
 	"context"
-	"github.com/elastic/cloud-sdk-go/pkg/models"
+
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
 )
 
 // flattenStackVersionEnterpriseSearchConfig takes a StackVersionEnterpriseSearchConfig and flattens it.

--- a/ec/ecdatasource/stackdatasource/flatteners_enterprise_search_test.go
+++ b/ec/ecdatasource/stackdatasource/flatteners_enterprise_search_test.go
@@ -19,13 +19,15 @@ package stackdatasource
 
 import (
 	"context"
-	"github.com/elastic/terraform-provider-ec/ec/internal/util"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
-	"testing"
 
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+
+	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )
 
 func Test_flattenEnterpriseSearchResources(t *testing.T) {

--- a/ec/ecdatasource/stackdatasource/flatteners_kibana.go
+++ b/ec/ecdatasource/stackdatasource/flatteners_kibana.go
@@ -19,10 +19,12 @@ package stackdatasource
 
 import (
 	"context"
-	"github.com/elastic/cloud-sdk-go/pkg/models"
+
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
 )
 
 // flattenStackVersionKibanaConfig takes a StackVersionKibanaConfig and flattens it.

--- a/ec/ecdatasource/stackdatasource/flatteners_kibana_test.go
+++ b/ec/ecdatasource/stackdatasource/flatteners_kibana_test.go
@@ -19,13 +19,15 @@ package stackdatasource
 
 import (
 	"context"
-	"github.com/elastic/terraform-provider-ec/ec/internal/util"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
-	"testing"
 
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+
+	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )
 
 func Test_flattenKibanaResources(t *testing.T) {

--- a/ec/ecdatasource/stackdatasource/schema.go
+++ b/ec/ecdatasource/stackdatasource/schema.go
@@ -19,13 +19,14 @@ package stackdatasource
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func (s DataSourceType) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+func (d *DataSource) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
 	return tfsdk.Schema{
 		Attributes: map[string]tfsdk.Attribute{
 			"version_regex": {

--- a/ec/ecresource/deploymentresource/apm_expanders_test.go
+++ b/ec/ecresource/deploymentresource/apm_expanders_test.go
@@ -21,10 +21,11 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_expandApmResources(t *testing.T) {

--- a/ec/ecresource/deploymentresource/apm_flatteners_test.go
+++ b/ec/ecresource/deploymentresource/apm_flatteners_test.go
@@ -20,10 +20,11 @@ package deploymentresource
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_flattenApmResource(t *testing.T) {

--- a/ec/ecresource/deploymentresource/create.go
+++ b/ec/ecresource/deploymentresource/create.go
@@ -21,11 +21,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 // createResource will createResource a new deployment from the specified settings.

--- a/ec/ecresource/deploymentresource/delete.go
+++ b/ec/ecresource/deploymentresource/delete.go
@@ -22,13 +22,14 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi"
 	"github.com/elastic/cloud-sdk-go/pkg/client/deployments"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 // Delete shuts down and deletes the remote deployment retrying up to 3 times

--- a/ec/ecresource/deploymentresource/delete_test.go
+++ b/ec/ecresource/deploymentresource/delete_test.go
@@ -22,12 +22,14 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )

--- a/ec/ecresource/deploymentresource/elasticsearch_expanders.go
+++ b/ec/ecresource/deploymentresource/elasticsearch_expanders.go
@@ -24,10 +24,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/deploymentsize"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )

--- a/ec/ecresource/deploymentresource/elasticsearch_expanders_test.go
+++ b/ec/ecresource/deploymentresource/elasticsearch_expanders_test.go
@@ -21,11 +21,12 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_expandEsResource(t *testing.T) {

--- a/ec/ecresource/deploymentresource/elasticsearch_flatteners.go
+++ b/ec/ecresource/deploymentresource/elasticsearch_flatteners.go
@@ -24,8 +24,9 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
 
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )

--- a/ec/ecresource/deploymentresource/elasticsearch_flatteners_test.go
+++ b/ec/ecresource/deploymentresource/elasticsearch_flatteners_test.go
@@ -20,11 +20,12 @@ package deploymentresource
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_flattenEsResource(t *testing.T) {

--- a/ec/ecresource/deploymentresource/elasticsearch_remote_cluster_expanders.go
+++ b/ec/ecresource/deploymentresource/elasticsearch_remote_cluster_expanders.go
@@ -18,11 +18,12 @@
 package deploymentresource
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/esremoteclustersapi"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func handleRemoteClusters(d *schema.ResourceData, client *api.API) error {

--- a/ec/ecresource/deploymentresource/elasticsearch_remote_cluster_expanders_test.go
+++ b/ec/ecresource/deploymentresource/elasticsearch_remote_cluster_expanders_test.go
@@ -20,12 +20,13 @@ package deploymentresource
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )

--- a/ec/ecresource/deploymentresource/enterprise_search_expanders_test.go
+++ b/ec/ecresource/deploymentresource/enterprise_search_expanders_test.go
@@ -21,10 +21,11 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_expandEssResources(t *testing.T) {

--- a/ec/ecresource/deploymentresource/enterprise_search_flatteners_test.go
+++ b/ec/ecresource/deploymentresource/enterprise_search_flatteners_test.go
@@ -20,10 +20,11 @@ package deploymentresource
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_flattenEssResource(t *testing.T) {

--- a/ec/ecresource/deploymentresource/expanders.go
+++ b/ec/ecresource/deploymentresource/expanders.go
@@ -21,13 +21,14 @@ import (
 	"fmt"
 	"sort"
 
-	semver "github.com/blang/semver/v4"
+	"github.com/blang/semver/v4"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/deptemplateapi"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )

--- a/ec/ecresource/deploymentresource/expanders_test.go
+++ b/ec/ecresource/deploymentresource/expanders_test.go
@@ -24,13 +24,14 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )

--- a/ec/ecresource/deploymentresource/flatteners.go
+++ b/ec/ecresource/deploymentresource/flatteners.go
@@ -22,10 +22,11 @@ import (
 	"fmt"
 	"strings"
 
-	semver "github.com/blang/semver/v4"
+	"github.com/blang/semver/v4"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )

--- a/ec/ecresource/deploymentresource/flatteners_test.go
+++ b/ec/ecresource/deploymentresource/flatteners_test.go
@@ -21,11 +21,12 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )

--- a/ec/ecresource/deploymentresource/import.go
+++ b/ec/ecresource/deploymentresource/import.go
@@ -22,7 +22,8 @@ import (
 	"errors"
 	"fmt"
 
-	semver "github.com/blang/semver/v4"
+	"github.com/blang/semver/v4"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/deputil"

--- a/ec/ecresource/deploymentresource/import_test.go
+++ b/ec/ecresource/deploymentresource/import_test.go
@@ -22,11 +22,12 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )

--- a/ec/ecresource/deploymentresource/integrations_server_expanders_test.go
+++ b/ec/ecresource/deploymentresource/integrations_server_expanders_test.go
@@ -21,10 +21,11 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_expandIntegrationsServerResources(t *testing.T) {

--- a/ec/ecresource/deploymentresource/integrations_server_flatteners_test.go
+++ b/ec/ecresource/deploymentresource/integrations_server_flatteners_test.go
@@ -20,10 +20,11 @@ package deploymentresource
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_flattenIntegrationsServerResource(t *testing.T) {

--- a/ec/ecresource/deploymentresource/kibana_expanders_test.go
+++ b/ec/ecresource/deploymentresource/kibana_expanders_test.go
@@ -21,10 +21,11 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_expandKibanaResources(t *testing.T) {

--- a/ec/ecresource/deploymentresource/kibana_flatteners_test.go
+++ b/ec/ecresource/deploymentresource/kibana_flatteners_test.go
@@ -20,10 +20,11 @@ package deploymentresource
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_flattenKibanaResources(t *testing.T) {

--- a/ec/ecresource/deploymentresource/observability_test.go
+++ b/ec/ecresource/deploymentresource/observability_test.go
@@ -20,11 +20,12 @@ package deploymentresource
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestFlattenObservability(t *testing.T) {

--- a/ec/ecresource/deploymentresource/read.go
+++ b/ec/ecresource/deploymentresource/read.go
@@ -21,6 +21,9 @@ import (
 	"context"
 	"errors"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi"
@@ -29,8 +32,6 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/client/deployments"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 // Read queries the remote deployment state and updates the local state.

--- a/ec/ecresource/deploymentresource/read_test.go
+++ b/ec/ecresource/deploymentresource/read_test.go
@@ -21,16 +21,18 @@ import (
 	"context"
 	"testing"
 
+	"github.com/go-openapi/runtime"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/client/deployments"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/go-openapi/runtime"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )

--- a/ec/ecresource/deploymentresource/schema_elasticsearch.go
+++ b/ec/ecresource/deploymentresource/schema_elasticsearch.go
@@ -23,9 +23,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/elastic/cloud-sdk-go/pkg/util/slice"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/elastic/cloud-sdk-go/pkg/util/slice"
 )
 
 func newElasticsearchResource() *schema.Resource {

--- a/ec/ecresource/deploymentresource/stopped_resource_test.go
+++ b/ec/ecresource/deploymentresource/stopped_resource_test.go
@@ -20,9 +20,10 @@ package deploymentresource
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_isApmResourceStopped(t *testing.T) {

--- a/ec/ecresource/deploymentresource/testutil_func.go
+++ b/ec/ecresource/deploymentresource/testutil_func.go
@@ -23,8 +23,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
 )
 
 // parseDeploymentTemplate is a test helper which parse a file by path and

--- a/ec/ecresource/deploymentresource/testutil_func_test.go
+++ b/ec/ecresource/deploymentresource/testutil_func_test.go
@@ -21,9 +21,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_parseDeploymentTemplate(t *testing.T) {

--- a/ec/ecresource/deploymentresource/traffic_filter.go
+++ b/ec/ecresource/deploymentresource/traffic_filter.go
@@ -18,8 +18,9 @@
 package deploymentresource
 
 import (
-	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
 
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )

--- a/ec/ecresource/deploymentresource/traffic_filter_test.go
+++ b/ec/ecresource/deploymentresource/traffic_filter_test.go
@@ -20,9 +20,10 @@ package deploymentresource
 import (
 	"testing"
 
-	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
 )
 
 func TestParseTrafficFiltering(t *testing.T) {

--- a/ec/ecresource/deploymentresource/update.go
+++ b/ec/ecresource/deploymentresource/update.go
@@ -21,11 +21,12 @@ import (
 	"context"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 // Update syncs the remote state with the local.

--- a/ec/ecresource/deploymentresource/update_test.go
+++ b/ec/ecresource/deploymentresource/update_test.go
@@ -20,9 +20,10 @@ package deploymentresource
 import (
 	"testing"
 
-	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )

--- a/ec/ecresource/deploymentresource/update_traffic_rules.go
+++ b/ec/ecresource/deploymentresource/update_traffic_rules.go
@@ -18,9 +18,10 @@
 package deploymentresource
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/trafficfilterapi"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )

--- a/ec/ecresource/elasticsearchkeystoreresource/create.go
+++ b/ec/ecresource/elasticsearchkeystoreresource/create.go
@@ -22,9 +22,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/eskeystoreapi"
 )

--- a/ec/ecresource/elasticsearchkeystoreresource/delete.go
+++ b/ec/ecresource/elasticsearchkeystoreresource/delete.go
@@ -20,9 +20,10 @@ package elasticsearchkeystoreresource
 import (
 	"context"
 
-	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/eskeystoreapi"
 )

--- a/ec/ecresource/elasticsearchkeystoreresource/expanders.go
+++ b/ec/ecresource/elasticsearchkeystoreresource/expanders.go
@@ -20,9 +20,10 @@ package elasticsearchkeystoreresource
 import (
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func expandModel(d *schema.ResourceData) *models.KeystoreContents {

--- a/ec/ecresource/elasticsearchkeystoreresource/expanders_test.go
+++ b/ec/ecresource/elasticsearchkeystoreresource/expanders_test.go
@@ -20,11 +20,12 @@ package elasticsearchkeystoreresource
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_expandModel(t *testing.T) {

--- a/ec/ecresource/elasticsearchkeystoreresource/read.go
+++ b/ec/ecresource/elasticsearchkeystoreresource/read.go
@@ -20,10 +20,11 @@ package elasticsearchkeystoreresource
 import (
 	"context"
 
-	"github.com/elastic/cloud-sdk-go/pkg/api"
-	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/eskeystoreapi"
 )

--- a/ec/ecresource/elasticsearchkeystoreresource/read_test.go
+++ b/ec/ecresource/elasticsearchkeystoreresource/read_test.go
@@ -20,11 +20,12 @@ package elasticsearchkeystoreresource
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_modelToState(t *testing.T) {

--- a/ec/ecresource/elasticsearchkeystoreresource/update.go
+++ b/ec/ecresource/elasticsearchkeystoreresource/update.go
@@ -20,9 +20,10 @@ package elasticsearchkeystoreresource
 import (
 	"context"
 
-	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/eskeystoreapi"
 )

--- a/ec/ecresource/extensionresource/create.go
+++ b/ec/ecresource/extensionresource/create.go
@@ -20,12 +20,13 @@ package extensionresource
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/extensionapi"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 // createResource will create a new deployment extension

--- a/ec/ecresource/extensionresource/create_test.go
+++ b/ec/ecresource/extensionresource/create_test.go
@@ -21,11 +21,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/elastic/cloud-sdk-go/pkg/api"
-	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )

--- a/ec/ecresource/extensionresource/delete.go
+++ b/ec/ecresource/extensionresource/delete.go
@@ -21,11 +21,12 @@ import (
 	"context"
 	"errors"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/extensionapi"
 	"github.com/elastic/cloud-sdk-go/pkg/client/extensions"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func deleteResource(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/ec/ecresource/extensionresource/delete_test.go
+++ b/ec/ecresource/extensionresource/delete_test.go
@@ -21,11 +21,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/elastic/cloud-sdk-go/pkg/api"
-	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )

--- a/ec/ecresource/extensionresource/read.go
+++ b/ec/ecresource/extensionresource/read.go
@@ -21,13 +21,14 @@ import (
 	"context"
 	"errors"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/extensionapi"
 	"github.com/elastic/cloud-sdk-go/pkg/client/extensions"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func readResource(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/ec/ecresource/extensionresource/read_test.go
+++ b/ec/ecresource/extensionresource/read_test.go
@@ -22,15 +22,15 @@ import (
 	"testing"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
 
-	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/stretchr/testify/assert"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )

--- a/ec/ecresource/extensionresource/update.go
+++ b/ec/ecresource/extensionresource/update.go
@@ -20,12 +20,13 @@ package extensionresource
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/extensionapi"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func updateResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/ec/ecresource/extensionresource/update_test.go
+++ b/ec/ecresource/extensionresource/update_test.go
@@ -21,14 +21,16 @@ import (
 	"context"
 	"testing"
 
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/go-openapi/strfmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )

--- a/ec/ecresource/extensionresource/upload.go
+++ b/ec/ecresource/extensionresource/upload.go
@@ -20,10 +20,11 @@ package extensionresource
 import (
 	"os"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/extensionapi"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func uploadExtension(client *api.API, d *schema.ResourceData) error {

--- a/ec/ecresource/trafficfilterassocresource/create.go
+++ b/ec/ecresource/trafficfilterassocresource/create.go
@@ -20,12 +20,24 @@ package trafficfilterassocresource
 import (
 	"context"
 	"fmt"
-	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/trafficfilterapi"
+
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/trafficfilterapi"
 )
 
-func (t trafficFilterAssocResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
+func (r Resource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
+	// Prevent panic if the provider has not been configured.
+	if r.client == nil {
+		response.Diagnostics.AddError(
+			"Unconfigured API Client",
+			"Expected configured API client. Please report this issue to the provider developers.",
+		)
+
+		return
+	}
+
 	var newState modelV0
 
 	diags := request.Plan.Get(ctx, &newState)
@@ -35,7 +47,7 @@ func (t trafficFilterAssocResource) Create(ctx context.Context, request resource
 	}
 
 	if err := trafficfilterapi.CreateAssociation(trafficfilterapi.CreateAssociationParams{
-		API:        t.provider.GetClient(),
+		API:        r.client,
 		ID:         newState.TrafficFilterID.Value,
 		EntityID:   newState.DeploymentID.Value,
 		EntityType: entityTypeDeployment,

--- a/ec/ecresource/trafficfilterassocresource/import_state.go
+++ b/ec/ecresource/trafficfilterassocresource/import_state.go
@@ -20,12 +20,13 @@ package trafficfilterassocresource
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"strings"
 )
 
-func (t trafficFilterAssocResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
+func (r Resource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
 	idParts := strings.Split(request.ID, ",")
 
 	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {

--- a/ec/ecresource/trafficfilterassocresource/read.go
+++ b/ec/ecresource/trafficfilterassocresource/read.go
@@ -19,12 +19,25 @@ package trafficfilterassocresource
 
 import (
 	"context"
-	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/trafficfilterapi"
-	"github.com/elastic/terraform-provider-ec/ec/internal/util"
+
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/trafficfilterapi"
+
+	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )
 
-func (t trafficFilterAssocResource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
+func (r Resource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
+	// Prevent panic if the provider has not been configured.
+	if r.client == nil {
+		response.Diagnostics.AddError(
+			"Unconfigured API Client",
+			"Expected configured API client. Please report this issue to the provider developers.",
+		)
+
+		return
+	}
+
 	var state modelV0
 
 	diags := request.State.Get(ctx, &state)
@@ -34,7 +47,7 @@ func (t trafficFilterAssocResource) Read(ctx context.Context, request resource.R
 	}
 
 	res, err := trafficfilterapi.Get(trafficfilterapi.GetParams{
-		API:                 t.provider.GetClient(),
+		API:                 r.client,
 		ID:                  state.TrafficFilterID.Value,
 		IncludeAssociations: true,
 	})

--- a/ec/ecresource/trafficfilterassocresource/resource_test.go
+++ b/ec/ecresource/trafficfilterassocresource/resource_test.go
@@ -18,16 +18,18 @@
 package trafficfilterassocresource_test
 
 import (
-	"github.com/elastic/cloud-sdk-go/pkg/api"
-	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
-	"github.com/elastic/terraform-provider-ec/ec"
-	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"net/url"
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	r "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+
+	"github.com/elastic/terraform-provider-ec/ec"
 )
 
 func TestResourceTrafficFilterAssoc(t *testing.T) {

--- a/ec/ecresource/trafficfilterassocresource/update.go
+++ b/ec/ecresource/trafficfilterassocresource/update.go
@@ -19,9 +19,10 @@ package trafficfilterassocresource
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
-func (t trafficFilterAssocResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
+func (r Resource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
 	panic("ec_deployment_traffic_filter_association resources can not be updated!")
 }

--- a/ec/ecresource/trafficfilterresource/create.go
+++ b/ec/ecresource/trafficfilterresource/create.go
@@ -20,10 +20,11 @@ package trafficfilterresource
 import (
 	"context"
 
-	"github.com/elastic/cloud-sdk-go/pkg/api"
-	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/trafficfilterapi"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/trafficfilterapi"
 )
 
 // Create will create a new deployment traffic filter ruleset

--- a/ec/ecresource/trafficfilterresource/delete.go
+++ b/ec/ecresource/trafficfilterresource/delete.go
@@ -21,11 +21,12 @@ import (
 	"context"
 	"errors"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/trafficfilterapi"
 	"github.com/elastic/cloud-sdk-go/pkg/client/deployments_traffic_filter"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )

--- a/ec/ecresource/trafficfilterresource/delete_test.go
+++ b/ec/ecresource/trafficfilterresource/delete_test.go
@@ -21,14 +21,17 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_delete(t *testing.T) {

--- a/ec/ecresource/trafficfilterresource/expanders.go
+++ b/ec/ecresource/trafficfilterresource/expanders.go
@@ -18,9 +18,10 @@
 package trafficfilterresource
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func expandModel(d *schema.ResourceData) *models.TrafficFilterRulesetRequest {

--- a/ec/ecresource/trafficfilterresource/expanders_test.go
+++ b/ec/ecresource/trafficfilterresource/expanders_test.go
@@ -20,10 +20,11 @@ package trafficfilterresource
 import (
 	"testing"
 
-	"github.com/elastic/cloud-sdk-go/pkg/models"
-	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )

--- a/ec/ecresource/trafficfilterresource/flatteners.go
+++ b/ec/ecresource/trafficfilterresource/flatteners.go
@@ -18,8 +18,9 @@
 package trafficfilterresource
 
 import (
-	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
 )
 
 func modelToState(d *schema.ResourceData, res *models.TrafficFilterRulesetInfo) error {

--- a/ec/ecresource/trafficfilterresource/flatteners_test.go
+++ b/ec/ecresource/trafficfilterresource/flatteners_test.go
@@ -20,10 +20,11 @@ package trafficfilterresource
 import (
 	"testing"
 
-	"github.com/elastic/cloud-sdk-go/pkg/models"
-	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )

--- a/ec/ecresource/trafficfilterresource/read.go
+++ b/ec/ecresource/trafficfilterresource/read.go
@@ -20,10 +20,11 @@ package trafficfilterresource
 import (
 	"context"
 
-	"github.com/elastic/cloud-sdk-go/pkg/api"
-	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/trafficfilterapi"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/trafficfilterapi"
 
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )

--- a/ec/ecresource/trafficfilterresource/read_test.go
+++ b/ec/ecresource/trafficfilterresource/read_test.go
@@ -21,11 +21,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/elastic/cloud-sdk-go/pkg/api"
-	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )

--- a/ec/ecresource/trafficfilterresource/update.go
+++ b/ec/ecresource/trafficfilterresource/update.go
@@ -20,10 +20,11 @@ package trafficfilterresource
 import (
 	"context"
 
-	"github.com/elastic/cloud-sdk-go/pkg/api"
-	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/trafficfilterapi"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/trafficfilterapi"
 )
 
 // Update will update an existing deployment traffic filter ruleset

--- a/ec/internal/flatteners/flatten_tags.go
+++ b/ec/internal/flatteners/flatten_tags.go
@@ -18,9 +18,10 @@
 package flatteners
 
 import (
-	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
 )
 
 // flattenTags takes in Deployment Metadata resource models and returns its

--- a/ec/internal/flatteners/flatten_tags_test.go
+++ b/ec/internal/flatteners/flatten_tags_test.go
@@ -21,9 +21,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestFlattenTags(t *testing.T) {

--- a/ec/internal/planmodifier/default_from_env.go
+++ b/ec/internal/planmodifier/default_from_env.go
@@ -20,10 +20,11 @@ package planmodifier
 import (
 	"context"
 	"fmt"
-	"github.com/elastic/terraform-provider-ec/ec/internal/util"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )
 
 // defaultFromEnvAttributePlanModifier specifies a default value (attr.Value) for an attribute.

--- a/ec/internal/util/helpers.go
+++ b/ec/internal/util/helpers.go
@@ -19,11 +19,12 @@ package util
 
 import (
 	"fmt"
+	"os"
+	"strconv"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"os"
-	"strconv"
 
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 )

--- a/ec/internal/util/helpers_test.go
+++ b/ec/internal/util/helpers_test.go
@@ -20,9 +20,10 @@ package util
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestFlattenClusterEndpoint(t *testing.T) {

--- a/ec/internal/util/parsers_test.go
+++ b/ec/internal/util/parsers_test.go
@@ -21,9 +21,10 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestMemoryToState(t *testing.T) {

--- a/ec/internal/util/testutils.go
+++ b/ec/internal/util/testutils.go
@@ -22,9 +22,10 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/elastic/cloud-sdk-go/pkg/multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
 )
 
 // ResDataParams holds the raw configuration for NewResourceData to consume

--- a/ec/internal/util/traffic_filter_err_test.go
+++ b/ec/internal/util/traffic_filter_err_test.go
@@ -20,9 +20,10 @@ package util
 import (
 	"testing"
 
+	"github.com/go-openapi/runtime"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
 	"github.com/elastic/cloud-sdk-go/pkg/client/deployments_traffic_filter"
-	"github.com/go-openapi/runtime"
 )
 
 func TestTrafficFilterNotFound(t *testing.T) {

--- a/ec/internal/validators/knownvalidator.go
+++ b/ec/internal/validators/knownvalidator.go
@@ -19,6 +19,7 @@ package validators
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 )
 

--- a/ec/provider_config.go
+++ b/ec/provider_config.go
@@ -24,12 +24,13 @@ import (
 	"os"
 	"time"
 
-	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/auth"
+
+	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )
 
 const (

--- a/ec/provider_config_test.go
+++ b/ec/provider_config_test.go
@@ -26,11 +26,12 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/auth"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -17,6 +17,7 @@
 
 // This program generates ec/version.go. It can be invoked by running
 // make generate
+//go:build ignore
 // +build ignore
 
 package main

--- a/go.mod
+++ b/go.mod
@@ -8,13 +8,13 @@ require (
 	github.com/elastic/cloud-sdk-go v1.10.0
 	github.com/go-openapi/runtime v0.24.1
 	github.com/go-openapi/strfmt v0.21.3
-	github.com/hashicorp/terraform-plugin-framework v0.11.1
+	github.com/hashicorp/terraform-plugin-framework v0.12.0
 	github.com/hashicorp/terraform-plugin-go v0.14.0
 	github.com/hashicorp/terraform-plugin-log v0.7.0
 	github.com/hashicorp/terraform-plugin-mux v0.7.0
-	github.com/hashicorp/terraform-plugin-sdk/v2 v2.21.0
+	github.com/hashicorp/terraform-plugin-sdk/v2 v2.22.0
 	github.com/stretchr/testify v1.8.0
-	golang.org/x/exp v0.0.0-20220827204233-334a2380cb91
+	golang.org/x/exp v0.0.0-20220914170420-dc92f8653013
 )
 
 require (
@@ -33,7 +33,7 @@ require (
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/go-openapi/validate v0.22.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/go-cmp v0.5.8 // indirect
+	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
@@ -44,9 +44,9 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/hashicorp/hc-install v0.4.0 // indirect
-	github.com/hashicorp/hcl/v2 v2.13.0 // indirect
+	github.com/hashicorp/hcl/v2 v2.14.0 // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect
-	github.com/hashicorp/terraform-exec v0.17.2 // indirect
+	github.com/hashicorp/terraform-exec v0.17.3 // indirect
 	github.com/hashicorp/terraform-json v0.14.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c // indirect
 	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 // indirect
@@ -68,13 +68,13 @@ require (
 	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
 	github.com/vmihailenco/tagparser v0.1.2 // indirect
 	github.com/zclconf/go-cty v1.11.0 // indirect
-	go.mongodb.org/mongo-driver v1.10.1 // indirect
-	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
-	golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b // indirect
-	golang.org/x/sys v0.0.0-20220829200755-d48e67d00261 // indirect
+	go.mongodb.org/mongo-driver v1.10.2 // indirect
+	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 // indirect
+	golang.org/x/net v0.0.0-20220909164309-bea034e7d591 // indirect
+	golang.org/x/sys v0.0.0-20220913175220-63ea55921009 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20220829175752-36a9c930ecbf // indirect
+	google.golang.org/genproto v0.0.0-20220914210030-581e60b4ef85 // indirect
 	google.golang.org/grpc v1.49.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,7 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYU
 github.com/apparentlymart/go-cidr v1.1.0 h1:2mAhrMoF+nhXqxTzSZMUzDHkLjmIHC+Zzn4tdgBZjnU=
 github.com/apparentlymart/go-cidr v1.1.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
 github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0 h1:MzVXffFUye+ZcSR6opIgz9Co7WcDx6ZcY+RjfFHoA0I=
+github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2wFoYVvnCs0=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
@@ -220,6 +221,8 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
@@ -251,14 +254,20 @@ github.com/hashicorp/hc-install v0.4.0 h1:cZkRFr1WVa0Ty6x5fTvL1TuO1flul231rWkGH9
 github.com/hashicorp/hc-install v0.4.0/go.mod h1:5d155H8EC5ewegao9A4PUTMNPZaq+TbOzkJJZ4vrXeI=
 github.com/hashicorp/hcl/v2 v2.13.0 h1:0Apadu1w6M11dyGFxWnmhhcMjkbAiKCv7G1r/2QgCNc=
 github.com/hashicorp/hcl/v2 v2.13.0/go.mod h1:e4z5nxYlWNPdDSNYX+ph14EvWYMFm3eP0zIUqPc2jr0=
+github.com/hashicorp/hcl/v2 v2.14.0 h1:jX6+Q38Ly9zaAJlAjnFVyeNSNCKKW8D0wvyg7vij5Wc=
+github.com/hashicorp/hcl/v2 v2.14.0/go.mod h1:e4z5nxYlWNPdDSNYX+ph14EvWYMFm3eP0zIUqPc2jr0=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.17.2 h1:EU7i3Fh7vDUI9nNRdMATCEfnm9axzTnad8zszYZ73Go=
 github.com/hashicorp/terraform-exec v0.17.2/go.mod h1:tuIbsL2l4MlwwIZx9HPM+LOV9vVyEfBYu2GsO1uH3/8=
+github.com/hashicorp/terraform-exec v0.17.3 h1:MX14Kvnka/oWGmIkyuyvL6POx25ZmKrjlaclkx3eErU=
+github.com/hashicorp/terraform-exec v0.17.3/go.mod h1:+NELG0EqQekJzhvikkeQsOAZpsw0cv/03rbeQJqscAI=
 github.com/hashicorp/terraform-json v0.14.0 h1:sh9iZ1Y8IFJLx+xQiKHGud6/TSUCM0N8e17dKDpqV7s=
 github.com/hashicorp/terraform-json v0.14.0/go.mod h1:5A9HIWPkk4e5aeeXIBbkcOvaZbIYnAIkEyqP2pNSckM=
 github.com/hashicorp/terraform-plugin-framework v0.11.1 h1:rq8f+TLDO4tJu+n9mMYlDrcRoIdrg0gTUvV2Jr0Ya24=
 github.com/hashicorp/terraform-plugin-framework v0.11.1/go.mod h1:GENReHOz6GEt8Jk3UN94vk8BdC6irEHFgN3Z9HPhPUU=
+github.com/hashicorp/terraform-plugin-framework v0.12.0 h1:Bk3l5MQUaZoo5eplr+u1FomYqGS564e8Tp3rutnCfYg=
+github.com/hashicorp/terraform-plugin-framework v0.12.0/go.mod h1:wcZdk4+Uef6Ng+BiBJjGAcIPlIs5bhlEV/TA1k6Xkq8=
 github.com/hashicorp/terraform-plugin-go v0.14.0 h1:ttnSlS8bz3ZPYbMb84DpcPhY4F5DsQtcAS7cHo8uvP4=
 github.com/hashicorp/terraform-plugin-go v0.14.0/go.mod h1:2nNCBeRLaenyQEi78xrGrs9hMbulveqG/zDMQSvVJTE=
 github.com/hashicorp/terraform-plugin-log v0.7.0 h1:SDxJUyT8TwN4l5b5/VkiTIaQgY6R+Y2BQ0sRZftGKQs=
@@ -267,6 +276,8 @@ github.com/hashicorp/terraform-plugin-mux v0.7.0 h1:wRbSYzg+v2sn5Mdee0UKm4YTt4wJ
 github.com/hashicorp/terraform-plugin-mux v0.7.0/go.mod h1:Ae30Mc5lz4d1awtiCbHP0YyvgBeiQ00Q1nAq0U3lb+I=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.21.0 h1:eIJjFlI4k6BMso6Wq/bq56U0RukXc4JbwJJ8Oze2/tg=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.21.0/go.mod h1:mYPs/uchNcBq7AclQv9QUtSf9iNcfp1Ag21jqTlDf2M=
+github.com/hashicorp/terraform-plugin-sdk/v2 v2.22.0 h1:MzfNfrheTt24xbEbA4npUSbX3GYu4xjXS7czcpJFyQY=
+github.com/hashicorp/terraform-plugin-sdk/v2 v2.22.0/go.mod h1:q1XKSxXg9nDmhV0IvNZNZxe3gcTAHzMqrjs8wX1acng=
 github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c h1:D8aRO6+mTqHfLsK/BC3j5OAoogv1WLRWzY1AaTo3rBg=
 github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c/go.mod h1:Wn3Na71knbXc1G8Lh+yu/dQWWJeFQEpDeJMtWMtlmNI=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=
@@ -428,6 +439,8 @@ go.mongodb.org/mongo-driver v1.8.3/go.mod h1:0sQWfOeY63QTntERDJJ/0SuKK0T1uVSgKCu
 go.mongodb.org/mongo-driver v1.10.0/go.mod h1:wsihk0Kdgv8Kqu1Anit4sfK+22vSFbUrAVEYRhCXrA8=
 go.mongodb.org/mongo-driver v1.10.1 h1:NujsPveKwHaWuKUer/ceo9DzEe7HIj1SlJ6uvXZG0S4=
 go.mongodb.org/mongo-driver v1.10.1/go.mod h1:z4XpeoU6w+9Vht+jAFyLgVrD+jGSQQe0+CBWFHNiHt8=
+go.mongodb.org/mongo-driver v1.10.2 h1:4Wk3cnqOrQCn0P92L3/mmurMxzdvWWs5J9jinAVKD+k=
+go.mongodb.org/mongo-driver v1.10.2/go.mod h1:z4XpeoU6w+9Vht+jAFyLgVrD+jGSQQe0+CBWFHNiHt8=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190219172222-a4c6cb3142f2/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -444,8 +457,12 @@ golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d h1:sK3txAijHtOK88l68nt020reeT1ZdKLIYetKl95FzVY=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 h1:Y/gsMcFOcR+6S6f3YeMKl5g+dZMEWqcz5Czj/GWYbkM=
+golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20220827204233-334a2380cb91 h1:tnebWN09GYg9OLPss1KXj8txwZc6X6uMr6VFdcGNbHw=
 golang.org/x/exp v0.0.0-20220827204233-334a2380cb91/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
+golang.org/x/exp v0.0.0-20220914170420-dc92f8653013 h1:ZjglnWxEUdPyXl4o/j4T89SRCI+4X6NW6185PNLEOF4=
+golang.org/x/exp v0.0.0-20220914170420-dc92f8653013/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180811021610-c39426892332/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181005035420-146acd28ed58/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -473,6 +490,8 @@ golang.org/x/net v0.0.0-20211216030914-fe4d6282115f/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b h1:ZmngSVLe/wycRns9MKikG9OWIEjGcGAkacif7oYQaUY=
 golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+golang.org/x/net v0.0.0-20220909164309-bea034e7d591 h1:D0B/7al0LLrVC8aWF4+oxpv/m8bc7ViFfVS8/gXGdqI=
+golang.org/x/net v0.0.0-20220909164309-bea034e7d591/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -512,6 +531,8 @@ golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220829200755-d48e67d00261 h1:v6hYoSR9T5oet+pMXwUWkbiVqx/63mlHjefrHmxwfeY=
 golang.org/x/sys v0.0.0-20220829200755-d48e67d00261/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220913175220-63ea55921009 h1:PuvuRMeLWqsf/ZdT1UUZz0syhioyv1mzuFZsXs4fvhw=
+golang.org/x/sys v0.0.0-20220913175220-63ea55921009/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
@@ -541,6 +562,8 @@ google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20220829175752-36a9c930ecbf h1:Q5xNKbTSFwkuaaGaR7CMcXEM5sy19KYdUU8iF8/iRC0=
 google.golang.org/genproto v0.0.0-20220829175752-36a9c930ecbf/go.mod h1:dbqgFATTzChvnt+ujMdZwITVAJHFtfyN1qUhDqEiIlk=
+google.golang.org/genproto v0.0.0-20220914210030-581e60b4ef85 h1:lkYqfLZL9+9C+SltHOTeOHL6uueWYYkGp5NoeOZQsis=
+google.golang.org/genproto v0.0.0-20220914210030-581e60b4ef85/go.mod h1:0Nb8Qy+Sk5eDzHnzlStwW3itdNaWoZA5XeSG+R3JHSo=
 google.golang.org/grpc v1.49.0 h1:WTLtQzmQori5FUH25Pq4WT22oCsv8USpQ+F6rqtsmxw=
 google.golang.org/grpc v1.49.0/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=


### PR DESCRIPTION
Update to terraform-plugin-framework 0.12 and fix import order.

## Description
- provider has been replaced by client in datasources and resources. This way we could also get rid of the internal.Provider interface.
- Deprecated things have been removed/replaced. See https://github.com/hashicorp/terraform-plugin-framework/releases/tag/v0.12.0

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
